### PR TITLE
Fix typo of 'filesystem'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # hyperdrive-fuse
-A FUSE flesystem for Hyperdrive
+A FUSE filesystem for Hyperdrive


### PR DESCRIPTION
This PR fixes the README typo, but the typo still exists in the repository description.